### PR TITLE
growiが自動起動するようにした

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,11 +28,13 @@ services:
               -wait tcp://elasticsearch:9200
               -timeout 60s
               npm run server:prod"
+    restart: unless-stopped
     volumes:
       - growi_data:/data
 
   mongo:
     image: mongo:3.4
+    restart: unless-stopped
     volumes:
       - mongo_configdb:/data/configdb
       - mongo_db:/data/db
@@ -47,6 +49,7 @@ services:
       - "./bin/elasticsearch-plugin list | grep -q analysis-kuromoji || ./bin/elasticsearch-plugin install analysis-kuromoji;
         ./bin/elasticsearch-plugin list | grep -q analysis-icu || ./bin/elasticsearch-plugin install analysis-icu;
         /docker-entrypoint.sh elasticsearch"
+    restart: unless-stopped
     volumes:
       - es_data:/usr/share/elasticsearch/data
       - es_plugins:/usr/share/elasticsearch/plugins

--- a/examples/backup-mongodb-data/docker-compose.override.yml
+++ b/examples/backup-mongodb-data/docker-compose.override.yml
@@ -11,5 +11,6 @@ services:
       # - S3_TARGET_BUCKET_URL=s3://${Your Bucket Name}/        # change it
     links:
       - mongo:mongo
+    restart: unless-stopped
     volumes:
       - ./crontab/root:/var/spool/cron/crontabs/root

--- a/examples/https-portal/docker-compose.override.yml
+++ b/examples/https-portal/docker-compose.override.yml
@@ -16,6 +16,7 @@ services:
       FORCE_RENEW: 'true'
       WEBSOCKET: 'true'
       CLIENT_MAX_BODY_SIZE: 0
+    restart: unless-stopped
     volumes:
       - https-portal_data:/var/lib/https-portal
 

--- a/examples/integrate-with-hackmd/docker-compose.override.yml
+++ b/examples/integrate-with-hackmd/docker-compose.override.yml
@@ -16,6 +16,7 @@ services:
       - 127.0.0.1:3100:3000   # localhost only by default
     depends_on:
       - mariadb
+    restart: unless-stopped
 
   ##
   # MariaDB
@@ -28,6 +29,7 @@ services:
       - MYSQL_PASSWORD=hackmdpass
       - MYSQL_DATABASE=hackmd
       - MYSQL_RANDOM_ROOT_PASSWORD=true
+    restart: unless-stopped
     volumes:
       - mariadb_data:/var/lib/mysql
 

--- a/examples/multi-app/docker-compose.yml
+++ b/examples/multi-app/docker-compose.yml
@@ -20,6 +20,7 @@ services:
               -wait tcp://elasticsearch:9200
               -timeout 60s
               npm run server:prod"
+    restart: unless-stopped
     volumes:
       - growi_data_1:/data
 
@@ -42,6 +43,7 @@ services:
               -wait tcp://elasticsearch:9200
               -timeout 60s
               npm run server:prod"
+    restart: unless-stopped
     volumes:
       - growi_data_2:/data
 
@@ -64,11 +66,13 @@ services:
               -wait tcp://elasticsearch:9200
               -timeout 60s
               npm run server:prod"
+    restart: unless-stopped
     volumes:
       - growi_data_3:/data
 
   mongo:
     image: mongo:3.4
+    restart: unless-stopped
     volumes:
       - mongo_configdb:/data/configdb
       - mongo_db:/data/db
@@ -83,6 +87,7 @@ services:
       - "./bin/elasticsearch-plugin list | grep -q analysis-kuromoji || ./bin/elasticsearch-plugin install analysis-kuromoji;
         ./bin/elasticsearch-plugin list | grep -q analysis-icu || ./bin/elasticsearch-plugin install analysis-icu;
         /docker-entrypoint.sh elasticsearch"
+    restart: unless-stopped
     volumes:
       - es_data:/usr/share/elasticsearch/data
       - es_plugins:/usr/share/elasticsearch/plugins


### PR DESCRIPTION
現状だと、マシンを再起動をしたときにgrowiが自動的に起動しません。
dockerのrestart policyを設定して、growiと依存するサービスが自動的に起動するようにしました。