### PR TITLE
Deal with CVE-2021-44228 by adding another global environment variable for elasticsearch container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,7 @@ services:
     environment:
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms256m -Xmx256m"  # increase amount if you have enough memory
+      - LOG4J_FORMAT_MSG_NO_LOOKUPS=true # CVE-2021-44228 mitigation for Elasticsearch <= 6.8.20/7.16.0
     ulimits:
       memlock:
         soft: -1


### PR DESCRIPTION
Fixes #50
Closes #52

https://www.jpcert.or.jp/at/2021/at210050.html

> Log4jバージョン2.10およびそれ以降
> - （略）
> - 環境変数「LOG4J_FORMAT_MSG_NO_LOOKUPS」を「true」に設定する