### PR TITLE
Deal with CVE-2021-44228 by motifying `ES_JAVA_OPTS`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,8 @@ services:
       dockerfile: ./Dockerfile
     environment:
       - bootstrap.memory_lock=true
-      - "ES_JAVA_OPTS=-Xms256m -Xmx256m"  # increase amount if you have enough memory
+      - "ES_JAVA_OPTS=-Xms256m -Xmx256m -Dlog4j2.formatMsgNoLookups=true"  # increase amount if you have enough memory
+    # `-Dlog4j2.formatMsgNoLookups=true` is CVE-2021-44228 patch for Elasticsearch <= 6.8.20/7.16.0; never delete it unless updated to a newer version
     ulimits:
       memlock:
         soft: -1


### PR DESCRIPTION
Fixes #50 
Closes #51 


https://www.jpcert.or.jp/at/2021/at210050.html

> Log4jバージョン2.10およびそれ以降
> - Log4jを実行するJava仮想マシンを起動時に「log4j2.formatMsgNoLookups」
>   というJVMフラグオプションを指定する
> - (略)

https://github.com/elastic/elasticsearch/issues/81618#issuecomment-990570546

> This can be mitigated for the time being by adding `-Dlog4j2.formatMsgNoLookups=true` to `ES_JAVA_OPTS`

#51 と比較すると、ユーザ側の`docker-compose.yml`で`ES_JAVA_OPTS`を書き換えられると効かないというデメリットがあります。