### PR TITLE
Upgrade Elastic container base version to 6.8.21

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:6.8.10
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.8.21
 LABEL maintainer Yuki Takei <yuki@weseek.co.jp>
 
 RUN bin/elasticsearch-plugin install analysis-kuromoji


### PR DESCRIPTION
Fixes #50 

https://discuss.elastic.co/t/apache-log4j2-remote-code-execution-rce-vulnerability-cve-2021-44228-esa-2021-31/291476

> Users may upgrade to Elasticsearch 7.16.1 or 6.8.21, which were released on December 13, 2021. These releases do not upgrade the Log4j package, but mitigate the vulnerability by setting the JVM option 3.7k -Dlog4j2.formatMsgNoLookups=true and remove the vulnerable JndiLookup class from the Log4j package.