### PR TITLE
Upgrade Elasticsearch to 6.8.22

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:6.8.21
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.8.22
 LABEL maintainer Yuki Takei <yuki@weseek.co.jp>
 
 RUN bin/elasticsearch-plugin install analysis-kuromoji


### PR DESCRIPTION
https://www.elastic.co/guide/en/elasticsearch/reference/6.8/release-notes-6.8.22.html