### PR TITLE
upgrade mongodb-awesome-backup to 0.6.3

### DIFF
--- a/examples/backup-mongodb-data/README.md
+++ b/examples/backup-mongodb-data/README.md
@@ -36,7 +36,7 @@ Requirements
 4. Edit `./crontab/root` and specify the timing when you execute mongodb-awesome-backup.
 5. Set file permission `./crontab/root` to `root:root`.
 6. Edit `docker-compose.override.yml`
-    - Set `S3_TARGET_BUCKET_URL` to valid URL of S3 bucket.
+    - Set `TARGET_BUCKET_URL` to valid URL of S3 bucket.
     - Set `SOME_FILE_NAME` to valid path of environment file you create.
 7. Execute GROWI with backup
     - `docker-compose up`
@@ -50,7 +50,7 @@ You can use these environment values in `environment` section in `docker-compose
 
 - AWS_ACCESS_KEY_ID
 - AWS_SECRET_ACCESS_KEY
-- S3_TARGET_BUCKET_URL
+- TARGET_BUCKET_URL
 - BACKUPFILE_PREFIX
 - MONGODB_HOST
 - MONGODB_DBNAME
@@ -68,10 +68,10 @@ For details, see the original site [weseek/mongodb-awesome-backup](https://githu
 ```yaml:docker-compose.override.yml
     : <snip>
   backup:
-    image: weseek/mongodb-awesome-backup:0.2.0
+    image: weseek/mongodb-awesome-backup:0.6.3
     environment:
       - CRONMODE=true
-      - S3_TARGET_BUCKET_URL=s3://${REPLACE_THIS_TO_YOUR_BUCKET_NAME}/
+      - TARGET_BUCKET_URL=s3://${REPLACE_THIS_TO_YOUR_BUCKET_NAME}/
       - AWS_ACCESS_KEY_ID=${Your IAM Access Key ID}
       - AWS_SECRET_ACCESS_KEY=${Your IAM Secret Access Key}
     links:

--- a/examples/backup-mongodb-data/README.md
+++ b/examples/backup-mongodb-data/README.md
@@ -29,16 +29,11 @@ Requirements
     AWS_ACCESS_KEY_ID=${Your IAM Access Key ID}
     AWS_SECRET_ACCESS_KEY=${Your IAM Secret Access Key}
     ```
-3. Copy config file of 'crond' to local repos root
-    ```
-    cp -rp examples/backup-mongodb-data/crontab .
-    ```
-4. Edit `./crontab/root` and specify the timing when you execute mongodb-awesome-backup.
-5. Set file permission `./crontab/root` to `root:root`.
-6. Edit `docker-compose.override.yml`
+3. Edit `docker-compose.override.yml`
+    - Set `CRON_EXPRESSION` to specify the timing when you execute mongodb-awesome-backup.
     - Set `TARGET_BUCKET_URL` to valid URL of S3 bucket.
     - Set `SOME_FILE_NAME` to valid path of environment file you create.
-7. Execute GROWI with backup
+4. Execute GROWI with backup
     - `docker-compose up`
 
 Then the backup container will be launched and it will backup MongoDB data to S3.
@@ -71,6 +66,7 @@ For details, see the original site [weseek/mongodb-awesome-backup](https://githu
     image: weseek/mongodb-awesome-backup:0.6.3
     environment:
       - CRONMODE=true
+      - CRON_EXPRESSION=0 4 * * *  
       - TARGET_BUCKET_URL=s3://${REPLACE_THIS_TO_YOUR_BUCKET_NAME}/
       - AWS_ACCESS_KEY_ID=${Your IAM Access Key ID}
       - AWS_SECRET_ACCESS_KEY=${Your IAM Secret Access Key}

--- a/examples/backup-mongodb-data/crontab/root
+++ b/examples/backup-mongodb-data/crontab/root
@@ -1,7 +1,0 @@
-# minute (0-59),
-# |  hour (0-23),
-# |  |  day of the month (1-31),
-# |  |  |  month of the year (1-12),
-# |  |  |  |  day of the week (0-6 with 0=Sunday).
-# |  |  |  |  |  commands
-  0  4  *  *  * /opt/bin/command_exec.sh backup prune list

--- a/examples/backup-mongodb-data/docker-compose.override.yml
+++ b/examples/backup-mongodb-data/docker-compose.override.yml
@@ -2,13 +2,13 @@ version: '3'
 
 services:
   backup:
-    image: weseek/mongodb-awesome-backup:0.2.0
+    image: weseek/mongodb-awesome-backup:0.6.3
     environment:
       - CRONMODE=true
       - CRON_EXPRESSION=0 4 * * *                               # change it
       # - AWS_ACCESS_KEY_ID=${Your IAM Access Key ID}           # change it
       # - AWS_SECRET_ACCESS_KEY=${Your IAM Secret Access Key}   # change it
-      # - S3_TARGET_BUCKET_URL=s3://${Your Bucket Name}/        # change it
+      # - TARGET_BUCKET_URL=s3://${Your Bucket Name}/        # change it
     links:
       - mongo:mongo
     restart: unless-stopped

--- a/examples/backup-mongodb-data/docker-compose.override.yml
+++ b/examples/backup-mongodb-data/docker-compose.override.yml
@@ -12,5 +12,3 @@ services:
     links:
       - mongo:mongo
     restart: unless-stopped
-    volumes:
-      - ./crontab/root:/var/spool/cron/crontabs/root


### PR DESCRIPTION
mongodbの定期バックアップを試したところ、バージョンの組み合わせが悪くエラーが発生していたため、その修正のプルリクエストです。

### mongodb-awesome-backup:0.2.0の場合
- backupコンテナ内のmongodumpバージョン
```
$ mongodump --version
mongodump version: v3.6.0-5503-gad663fbbd1
git version: ad663fbbd1fe8a775b61d634f7d85c8343dafe06
Go version: go1.9.2
   os: linux
   arch: amd64
   compiler: gc
OpenSSL version: LibreSSL 2.5.5
```
- mongoコンテナ内のmongodバージョン
```
$ mongod --version
db version v6.0.10
Build Info: {
    "version": "6.0.10",
    "gitVersion": "8e4b5670df9b9fe814e57cb5f3f8ee9407237b5a",
    "openSSLVersion": "OpenSSL 3.0.2 15 Mar 2022",
    "modules": [],
    "allocator": "tcmalloc",
    "environment": {
        "distmod": "ubuntu2204",
        "distarch": "x86_64",
        "target_arch": "x86_64"
    }
}
```
- コマンド実行時のエラー
```
$ /opt/bin/command_exec.sh backup prune list
=== ./backup.sh started at 2023/10/05 12:41:03 ===
dump MongoDB...
2023-10-05T12:41:07.015+0900    Failed: error connecting to db server: no reachable servers
```

### mongodb-awesome-backup:0.6.3に変更した場合
以下のmongodumpバージョンだと問題なく動作する
```
$ mongodump --version
mongodump version: v20200428-390-g50d72c4aaf
git version: 50d72c4aafa3c6e7e56eee03db6e469b622b2ebd
Go version: go1.13.10
   os: linux
   arch: amd64
   compiler: gc
```

0.6.3に変更したことで、環境変数の`S3_TARGET_BUCKET_URL`が`TARGET_BUCKET_URL`に変更になっていたため、README含め、合わせて修正を行っています。

ご確認よろしくお願いいたします。
