### PR TITLE
add pdf-converter config

### DIFF
--- a/docker-compose.es7.yml
+++ b/docker-compose.es7.yml
@@ -30,6 +30,7 @@ services:
     restart: unless-stopped
     volumes:
       - growi_data:/data
+      - page_bulk_export_tmp:/tmp/page-bulk-export
 
   mongo:
     image: mongo:6.0
@@ -65,8 +66,15 @@ services:
       timeout: 5s
       retries: 6
 
+  pdf-converter:
+    image: weseek/growi-pdf-converter:1
+    restart: unless-stopped
+    volumes:
+      - page_bulk_export_tmp:/tmp/page-bulk-export
+
 volumes:
   growi_data:
   mongo_configdb:
   mongo_db:
   es_data:
+  page_bulk_export_tmp:

--- a/docker-compose.es7.yml
+++ b/docker-compose.es7.yml
@@ -16,6 +16,7 @@ services:
     environment:
       - MONGO_URI=mongodb://mongo:27017/growi
       - ELASTICSEARCH_URI=http://elasticsearch:9200/growi
+      - BULK_EXPORT_PDF_CONVERTER_URI=http://pdf-converter:3010
       - PASSWORD_SEED=changeme
       # - FILE_UPLOAD=mongodb   # activate this line if you use MongoDB GridFS rather than AWS
       # - FILE_UPLOAD=local     # activate this line if you use local storage of server rather than AWS

--- a/docker-compose.es7.yml
+++ b/docker-compose.es7.yml
@@ -68,7 +68,7 @@ services:
       retries: 6
 
   pdf-converter:
-    image: weseek/growi-pdf-converter:1
+    image: growilabs/pdf-converter:1
     restart: unless-stopped
     volumes:
       - page_bulk_export_tmp:/tmp/page-bulk-export

--- a/docker-compose.v70x-es7.yml
+++ b/docker-compose.v70x-es7.yml
@@ -30,6 +30,7 @@ services:
     restart: unless-stopped
     volumes:
       - growi_data:/data
+      - page_bulk_export_tmp:/tmp/page-bulk-export
 
   mongo:
     image: mongo:6.0
@@ -65,8 +66,15 @@ services:
       timeout: 5s
       retries: 6
 
+  pdf-converter:
+    image: weseek/growi-pdf-converter:1
+    restart: unless-stopped
+    volumes:
+      - page_bulk_export_tmp:/tmp/page-bulk-export
+
 volumes:
   growi_data:
   mongo_configdb:
   mongo_db:
   es_data:
+  page_bulk_export_tmp:

--- a/docker-compose.v70x-es7.yml
+++ b/docker-compose.v70x-es7.yml
@@ -16,6 +16,7 @@ services:
     environment:
       - MONGO_URI=mongodb://mongo:27017/growi
       - ELASTICSEARCH_URI=http://elasticsearch:9200/growi
+      - BULK_EXPORT_PDF_CONVERTER_URI=http://pdf-converter:3010
       - PASSWORD_SEED=changeme
       # - FILE_UPLOAD=mongodb   # activate this line if you use MongoDB GridFS rather than AWS
       # - FILE_UPLOAD=local     # activate this line if you use local storage of server rather than AWS

--- a/docker-compose.v70x-es7.yml
+++ b/docker-compose.v70x-es7.yml
@@ -68,7 +68,7 @@ services:
       retries: 6
 
   pdf-converter:
-    image: weseek/growi-pdf-converter:1
+    image: growilabs/pdf-converter:1
     restart: unless-stopped
     volumes:
       - page_bulk_export_tmp:/tmp/page-bulk-export

--- a/docker-compose.v70x.yml
+++ b/docker-compose.v70x.yml
@@ -30,6 +30,7 @@ services:
     restart: unless-stopped
     volumes:
       - growi_data:/data
+      - page_bulk_export_tmp:/tmp/page-bulk-export
 
   mongo:
     image: mongo:6.0
@@ -65,8 +66,15 @@ services:
       timeout: 5s
       retries: 6
 
+  pdf-converter:
+    image: weseek/growi-pdf-converter:1
+    restart: unless-stopped
+    volumes:
+      - page_bulk_export_tmp:/tmp/page-bulk-export
+
 volumes:
   growi_data:
   mongo_configdb:
   mongo_db:
   es_data:
+  page_bulk_export_tmp:

--- a/docker-compose.v70x.yml
+++ b/docker-compose.v70x.yml
@@ -16,6 +16,7 @@ services:
     environment:
       - MONGO_URI=mongodb://mongo:27017/growi
       - ELASTICSEARCH_URI=http://elasticsearch:9200/growi
+      - BULK_EXPORT_PDF_CONVERTER_URI=http://pdf-converter:3010
       - PASSWORD_SEED=changeme
       # - FILE_UPLOAD=mongodb   # activate this line if you use MongoDB GridFS rather than AWS
       # - FILE_UPLOAD=local     # activate this line if you use local storage of server rather than AWS

--- a/docker-compose.v70x.yml
+++ b/docker-compose.v70x.yml
@@ -68,7 +68,7 @@ services:
       retries: 6
 
   pdf-converter:
-    image: weseek/growi-pdf-converter:1
+    image: growilabs/pdf-converter:1
     restart: unless-stopped
     volumes:
       - page_bulk_export_tmp:/tmp/page-bulk-export

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
     restart: unless-stopped
     volumes:
       - growi_data:/data
+      - page_bulk_export_tmp:/tmp/page-bulk-export
 
   mongo:
     image: mongo:6.0
@@ -65,8 +66,15 @@ services:
       timeout: 5s
       retries: 6
 
+  pdf-converter:
+    image: weseek/growi-pdf-converter:1
+    restart: unless-stopped
+    volumes:
+      - page_bulk_export_tmp:/tmp/page-bulk-export
+
 volumes:
   growi_data:
   mongo_configdb:
   mongo_db:
   es_data:
+  page_bulk_export_tmp:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     environment:
       - MONGO_URI=mongodb://mongo:27017/growi
       - ELASTICSEARCH_URI=http://elasticsearch:9200/growi
+      - BULK_EXPORT_PDF_CONVERTER_URI=http://pdf-converter:3010
       - PASSWORD_SEED=changeme
       # - FILE_UPLOAD=mongodb   # activate this line if you use MongoDB GridFS rather than AWS
       # - FILE_UPLOAD=local     # activate this line if you use local storage of server rather than AWS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,7 @@ services:
       retries: 6
 
   pdf-converter:
-    image: weseek/growi-pdf-converter:1
+    image: growilabs/pdf-converter:1
     restart: unless-stopped
     volumes:
       - page_bulk_export_tmp:/tmp/page-bulk-export


### PR DESCRIPTION
## 変更内容
- pdf-converter のコンテナを docker-compose に追加する
- pdf-converter と growi app のコンテナ間の shared volume を docker-compose に追加する

## レビューいただきたい点
pdf-converter のコンテナは、デフォルトで有効にしておくべきでしょうか？
それとも、コメントアウトしたり、有効化された docker-compose ファイルを別で作ったりして、デフォルトの docker-compose.yml では有効にしない方が良いでしょうか。

## task
https://redmine.weseek.co.jp/issues/159785

## 備考
pdf-converter がリリースされるまでマージできないため、draft にしてあります。